### PR TITLE
fix: unopinionate type preference

### DIFF
--- a/project/main.go
+++ b/project/main.go
@@ -3,7 +3,7 @@ package project
 import "fmt"
 
 // Version is ruleset version
-const Version string = "0.0.7"
+const Version string = "0.0.9"
 
 // ReferenceLink returns the rule reference link
 func ReferenceLink(name string) string {

--- a/rules/terraform_standard_module_structure.go
+++ b/rules/terraform_standard_module_structure.go
@@ -164,20 +164,19 @@ func (r *TerraformStandardModuleStructureRule) checkFiles(runner tflint.Runner, 
 	return nil
 }
 
-// bevorzugt .tofu – akzeptiere aber auch .tf
 func (r *TerraformStandardModuleStructureRule) checkVariables(runner tflint.Runner, variables hclext.Blocks) error {
 	for _, variable := range variables {
 		filename := variable.DefRange.Filename
 
-		if r.shouldMove(filename, filenameVariables) || r.shouldMove(filename, filenameTofuVariables) {
-			target := filenameTofuVariables
-			if filepath.Ext(filename) == ".tofu" {
-				target = filenameVariables
-			}
+		isVariablesTF := filepath.Base(filename) == filenameVariables
+		isVariablesTOFU := filepath.Base(filename) == filenameTofuVariables
+
+		if !isVariablesTF && !isVariablesTOFU && filepath.Ext(filename) != ".json" {
+			issueMsg := fmt.Sprintf("variable %q should be moved from %s to one of %s or %s", variable.Labels[0], filepath.Base(filename), filenameTofuVariables, filenameVariables)
 
 			if err := runner.EmitIssue(
 				r,
-				fmt.Sprintf("variable %q should be moved from %s to %s", variable.Labels[0], filename, target),
+				issueMsg,
 				variable.DefRange,
 			); err != nil {
 				return err
@@ -191,15 +190,14 @@ func (r *TerraformStandardModuleStructureRule) checkOutputs(runner tflint.Runner
 	for _, output := range outputs {
 		filename := output.DefRange.Filename
 
-		if r.shouldMove(filename, filenameOutputs) || r.shouldMove(filename, filenameTofuOutputs) {
-			target := filenameTofuOutputs
-			if filepath.Ext(filename) == ".tofu" {
-				target = filenameOutputs
-			}
+		isOutputsTF := filepath.Base(filename) == filenameOutputs
+		isOutputsTOFU := filepath.Base(filename) == filenameTofuOutputs
+		if !isOutputsTF && !isOutputsTOFU && filepath.Ext(filename) != ".json" {
+			issueMsg := fmt.Sprintf("output %q should be moved from %s to one of %s or %s", output.Labels[0], filepath.Base(filename), filenameTofuOutputs, filenameOutputs)
 
 			if err := runner.EmitIssue(
 				r,
-				fmt.Sprintf("output %q should be moved from %s to %s", output.Labels[0], filename, target),
+				issueMsg,
 				output.DefRange,
 			); err != nil {
 				return err

--- a/rules/terraform_standard_module_structure_test.go
+++ b/rules/terraform_standard_module_structure_test.go
@@ -68,21 +68,6 @@ variable "v" {}
 						Start:    hcl.InitialPos,
 					},
 				},
-				{
-					Rule:    NewTerraformStandardModuleStructureRule(),
-					Message: `variable "v" should be moved from foo/variables.tf to variables.tofu`,
-					Range: hcl.Range{
-						Filename: "foo/variables.tf",
-						Start: hcl.Pos{
-							Line:   2,
-							Column: 1,
-						},
-						End: hcl.Pos{
-							Line:   2,
-							Column: 13,
-						},
-					},
-				},
 			},
 		},
 		{
@@ -97,7 +82,7 @@ variable "v" {}
 			Expected: helper.Issues{
 				{
 					Rule:    NewTerraformStandardModuleStructureRule(),
-					Message: `variable "v" should be moved from main.tf to variables.tofu`,
+					Message: `variable "v" should be moved from main.tf to one of variables.tofu or variables.tf`,
 					Range: hcl.Range{
 						Filename: "main.tf",
 						Start: hcl.Pos{
@@ -124,7 +109,7 @@ output "o" { value = null }
 			Expected: helper.Issues{
 				{
 					Rule:    NewTerraformStandardModuleStructureRule(),
-					Message: `output "o" should be moved from main.tf to outputs.tofu`,
+					Message: `output "o" should be moved from main.tf to one of outputs.tofu or outputs.tf`,
 					Range: hcl.Range{
 						Filename: "main.tf",
 						Start: hcl.Pos{


### PR DESCRIPTION
###  Bug Fix: Remove Circular File Type Preference in Standard Module Structure Rule

This Pull Request resolves an issue within the `terraform_standard_module_structure` rule that caused incorrect warnings about file extensions, specifically between `.tf` and the new `.tofu` file types.

#### The Problem (Circular Preference)

Previously, the linter attempted to enforce a file structure standard but contained a logical flaw in the check for blocks (`variable` and `output`). Regardless of whether a block was correctly placed in its designated file (e.g., a `variable` in `variables.tf` or `variables.tofu`), the rule's logic created a **circular preference**:

* If a block was in `variables.tf`, the linter suggested moving it to `variables.tofu`.
* If a block was in `variables.tofu`, the linter suggested moving it to `variables.tf`.

This behavior resulted in the rule constantly reporting a `WARNING` even when the module structure was technically valid, preventing users from achieving a clean linting run.

#### The Fix

This PR entirely removes the circular preference logic. The `checkVariables` and `checkOutputs` functions are corrected to treat both standard file extensions equally.

The rule now correctly functions as intended:

* It only emits an issue if a block type (e.g., `variable` or `output`) is found in a **non-designated** file (e.g., a `variable` block found in `main.tf` or any file other than `variables.tf`/`.tofu`).
* Blocks found in either the `.tf` or `.tofu` version of the standard file (`variables.tf`, `variables.tofu`, `outputs.tf`, `outputs.tofu`) will now pass the check without a warning.
